### PR TITLE
fix: rename `c_status` to `agent_status`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ tcmux supports all tmux format variables (e.g., `#{window_index}`, `#{window_nam
 
 | Variable | Description |
 |----------|-------------|
-| `#{c_status}` | Claude Code status (context-dependent) |
+| `#{agent_status}` | Claude Code status (context-dependent) |
 
 - **list-windows:** `✻ Fix login bug [Idle], ✻ Add feature [Running (1m 30s, plan mode)]`
 - **list-sessions:** `2 Idle, 1 Running`
@@ -57,8 +57,8 @@ tcmux supports all tmux format variables (e.g., `#{window_index}`, `#{window_nam
 **Example:**
 
 ```console
-$ tcmux list-windows -F "#{window_index}:#{window_name} #{c_status}"
-$ tcmux list-sessions -F "#{session_name}: #{c_status}"
+$ tcmux list-windows -F "#{window_index}:#{window_name} #{agent_status}"
+$ tcmux list-sessions -F "#{session_name}: #{agent_status}"
 ```
 
 ### Recipe: Window switcher with Claude Code status

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const defaultSessionFormat = "#{session_name}: #{session_windows} windows#{?session_attached, (attached),} #{c_status}"
+const defaultSessionFormat = "#{session_name}: #{session_windows} windows#{?session_attached, (attached),} #{agent_status}"
 
 var lsFormat string
 

--- a/cmd/lsw.go
+++ b/cmd/lsw.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const defaultWindowFormat = "#{window_index}: #{window_name} (#{window_panes} panes) #{c_status}"
+const defaultWindowFormat = "#{window_index}: #{window_name} (#{window_panes} panes) #{agent_status}"
 
 var (
 	allWindows  bool
@@ -109,7 +109,7 @@ var lswCmd = &cobra.Command{
 			}
 
 			line := output.ExpandFormat(format, ctx)
-			// Trim trailing whitespace (in case c_status is empty)
+			// Trim trailing whitespace (in case agent_status is empty)
 			line = strings.TrimRight(line, " ")
 			results = append(results, line)
 		}

--- a/output/format.go
+++ b/output/format.go
@@ -11,7 +11,7 @@ import (
 
 // tcmux custom format variables
 const (
-	VarCStatus = "c_status" // Claude Code status (context-dependent output)
+	VarAgentStatus = "agent_status" // Coding agent status (context-dependent output)
 )
 
 var (
@@ -20,7 +20,7 @@ var (
 
 	// tcmux custom variables
 	tcmuxVars = map[string]bool{
-		VarCStatus: true,
+		VarAgentStatus: true,
 	}
 )
 
@@ -84,8 +84,8 @@ func ExpandFormat(format string, ctx *FormatContext) string {
 		varName := match[2 : len(match)-1]
 
 		switch varName {
-		case VarCStatus:
-			return formatCStatus(ctx.ClaudeInstances)
+		case VarAgentStatus:
+			return formatAgentStatus(ctx.ClaudeInstances)
 		default:
 			// tmux variable - use value from TmuxVars
 			if val, ok := ctx.TmuxVars[varName]; ok {
@@ -106,8 +106,8 @@ func ExpandSessionFormat(format string, ctx *SessionFormatContext) string {
 		varName := match[2 : len(match)-1]
 
 		switch varName {
-		case VarCStatus:
-			return formatCStats(ctx.IdleCount, ctx.RunningCount, ctx.WaitingCount)
+		case VarAgentStatus:
+			return formatAgentStats(ctx.IdleCount, ctx.RunningCount, ctx.WaitingCount)
 		default:
 			// tmux variable
 			if val, ok := ctx.TmuxVars[varName]; ok {
@@ -120,10 +120,10 @@ func ExpandSessionFormat(format string, ctx *SessionFormatContext) string {
 	return result
 }
 
-// formatCStatus formats the full Claude Code status string for multiple instances.
+// formatAgentStatus formats the full coding agent status string for multiple instances.
 // Format: "✻ summary [Status (description, mode)], ✻ summary2 [Status2]"
-// Returns empty string if no Claude Code instances.
-func formatCStatus(instances []ClaudeInfo) string {
+// Returns empty string if no coding agent instances.
+func formatAgentStatus(instances []ClaudeInfo) string {
 	if len(instances) == 0 {
 		return ""
 	}
@@ -184,8 +184,8 @@ func formatCStatus(instances []ClaudeInfo) string {
 	return strings.Join(instanceParts, ", ")
 }
 
-// formatCStats formats Claude Code statistics for a session.
-func formatCStats(idle, running, waiting int) string {
+// formatAgentStats formats coding agent statistics for a session.
+func formatAgentStats(idle, running, waiting int) string {
 	total := idle + running + waiting
 	if total == 0 {
 		return ""

--- a/output/format_test.go
+++ b/output/format_test.go
@@ -24,12 +24,12 @@ func TestExtractTmuxVars(t *testing.T) {
 		},
 		{
 			name:   "Exclude tcmux variables",
-			format: "#{window_index} #{c_status}",
+			format: "#{window_index} #{agent_status}",
 			want:   []string{"window_index"},
 		},
 		{
 			name:   "Only tcmux variables",
-			format: "#{c_status} #{c_status}",
+			format: "#{agent_status} #{agent_status}",
 			want:   nil,
 		},
 		{
@@ -79,8 +79,8 @@ func TestExpandFormat(t *testing.T) {
 			want: "0: editor",
 		},
 		{
-			name:   "Expand c_status with status only",
-			format: "#{c_status}",
+			name:   "Expand agent_status with status only",
+			format: "#{agent_status}",
 			ctx: &FormatContext{
 				TmuxVars: map[string]string{},
 				ClaudeInstances: []ClaudeInfo{
@@ -90,8 +90,8 @@ func TestExpandFormat(t *testing.T) {
 			want: "✻ [Idle]",
 		},
 		{
-			name:   "Expand c_status with summary and status",
-			format: "#{c_status}",
+			name:   "Expand agent_status with summary and status",
+			format: "#{agent_status}",
 			ctx: &FormatContext{
 				TmuxVars: map[string]string{},
 				ClaudeInstances: []ClaudeInfo{
@@ -101,8 +101,8 @@ func TestExpandFormat(t *testing.T) {
 			want: "✻ Fix login bug [Idle]",
 		},
 		{
-			name:   "Expand c_status with full status",
-			format: "#{c_status}",
+			name:   "Expand agent_status with full status",
+			format: "#{agent_status}",
 			ctx: &FormatContext{
 				TmuxVars: map[string]string{},
 				ClaudeInstances: []ClaudeInfo{
@@ -119,8 +119,8 @@ func TestExpandFormat(t *testing.T) {
 			want: "✻ Fix login bug [Running (1m 30s, plan mode)]",
 		},
 		{
-			name:   "Empty c_status when no instances",
-			format: "test #{c_status}",
+			name:   "Empty agent_status when no instances",
+			format: "test #{agent_status}",
 			ctx: &FormatContext{
 				TmuxVars:        map[string]string{},
 				ClaudeInstances: []ClaudeInfo{},
@@ -129,7 +129,7 @@ func TestExpandFormat(t *testing.T) {
 		},
 		{
 			name:   "Combined format",
-			format: "#{window_index}: #{window_name} #{c_status}",
+			format: "#{window_index}: #{window_name} #{agent_status}",
 			ctx: &FormatContext{
 				TmuxVars: map[string]string{
 					"window_index": "0",
@@ -143,7 +143,7 @@ func TestExpandFormat(t *testing.T) {
 		},
 		{
 			name:   "Multiple Claude Code instances",
-			format: "#{c_status}",
+			format: "#{agent_status}",
 			ctx: &FormatContext{
 				TmuxVars: map[string]string{},
 				ClaudeInstances: []ClaudeInfo{
@@ -172,8 +172,8 @@ func TestExpandSessionFormat(t *testing.T) {
 		want   string
 	}{
 		{
-			name:   "Expand c_status with all states",
-			format: "#{c_status}",
+			name:   "Expand agent_status with all states",
+			format: "#{agent_status}",
 			ctx: &SessionFormatContext{
 				TmuxVars:     map[string]string{},
 				IdleCount:    2,
@@ -183,8 +183,8 @@ func TestExpandSessionFormat(t *testing.T) {
 			want: "2 Idle, 1 Running, 1 Waiting",
 		},
 		{
-			name:   "Expand c_status with only idle",
-			format: "#{c_status}",
+			name:   "Expand agent_status with only idle",
+			format: "#{agent_status}",
 			ctx: &SessionFormatContext{
 				TmuxVars:  map[string]string{},
 				IdleCount: 3,
@@ -192,8 +192,8 @@ func TestExpandSessionFormat(t *testing.T) {
 			want: "3 Idle",
 		},
 		{
-			name:   "Empty c_status when no Claude Code",
-			format: "#{c_status}",
+			name:   "Empty agent_status when no Claude Code",
+			format: "#{agent_status}",
 			ctx: &SessionFormatContext{
 				TmuxVars: map[string]string{},
 			},
@@ -201,7 +201,7 @@ func TestExpandSessionFormat(t *testing.T) {
 		},
 		{
 			name:   "Combined session format",
-			format: "#{session_name}: #{session_windows} windows #{c_status}",
+			format: "#{session_name}: #{session_windows} windows #{agent_status}",
 			ctx: &SessionFormatContext{
 				TmuxVars: map[string]string{
 					"session_name":    "dev",


### PR DESCRIPTION
This pull request standardizes the naming for the custom status variable throughout the codebase, replacing the previous `c_status` (Claude Code status) with the more generic `agent_status` (coding agent status). This change improves clarity and generalizes the functionality for broader agent support. The update touches documentation, command-line defaults, code logic, and tests.

**Variable renaming and code updates:**

* Replaced all instances of `c_status` with `agent_status` in format strings, variable names, and comments across the codebase, including in `cmd/ls.go`, `cmd/lsw.go`, and `output/format.go`. [[1]](diffhunk://#diff-9865f1c8ef620ff3656b04fb97f95e74a92261123bd6aa1b937e156131409ca7L14-R14) [[2]](diffhunk://#diff-7e260bb9954e138f126df56c1f378a30adad4f6d678155cba5daaf773952cdffL13-R13) [[3]](diffhunk://#diff-48bc4eade1d14fa70291d309bb473d8853fb36d505ecc95266450b276f811bbaL14-R14) [[4]](diffhunk://#diff-48bc4eade1d14fa70291d309bb473d8853fb36d505ecc95266450b276f811bbaL23-R23) [[5]](diffhunk://#diff-48bc4eade1d14fa70291d309bb473d8853fb36d505ecc95266450b276f811bbaL87-R88) [[6]](diffhunk://#diff-48bc4eade1d14fa70291d309bb473d8853fb36d505ecc95266450b276f811bbaL109-R110) [[7]](diffhunk://#diff-48bc4eade1d14fa70291d309bb473d8853fb36d505ecc95266450b276f811bbaL123-R126) [[8]](diffhunk://#diff-48bc4eade1d14fa70291d309bb473d8853fb36d505ecc95266450b276f811bbaL187-R188) [[9]](diffhunk://#diff-7e260bb9954e138f126df56c1f378a30adad4f6d678155cba5daaf773952cdffL112-R112)

**Documentation and user-facing changes:**

* Updated the `README.md` to use `#{agent_status}` instead of `#{c_status}` in documentation and command examples.
