### PR TITLE
fix: improve status detection

### DIFF
--- a/claude/status_test.go
+++ b/claude/status_test.go
@@ -193,6 +193,50 @@ Enter to select · ↑/↓ to navigate · Esc to cancel`,
 			wantDesc:  "",
 		},
 		{
+			name: "Idle with file changes status line",
+			content: `⏺ Some output about "Do you want to proceed?"
+
+✻ Churned for 3m 5s
+
+! make install
+  ⎿  go install completed
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+❯
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  4 files +42 -0`,
+			wantState: StateIdle,
+			wantMode:  "",
+			wantDesc:  "",
+		},
+		{
+			name: "Waiting - Bash command confirmation dialog",
+			content: `⏺ Bash(gh issue view 395 --repo peco/peco 2>/dev/null || echo "Issue #395 not found or closed")
+  ⎿  title:     Close old issues (before 2016)
+     state:     CLOSED
+     author:    lestrrat
+     … +22 lines (ctrl+o to expand)
+
+⏺ Bash(fzf --help 2>/dev/null | grep -A5 -- "--ansi" || echo "fzf not installed or --ansi help not found")
+  ⎿  Running…
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ Bash command
+
+   fzf --help 2>/dev/null | grep -A5 -- "--ansi" || echo "fzf not installed or --ansi help not found"
+   Check fzf --ansi option help
+
+ Do you want to proceed?
+ ❯ 1. Yes
+   2. Yes, and don't ask again for fzf --help commands in /Users/k1low/src/github.com/peco/peco
+   3. No
+
+ Esc to cancel · Tab to amend · ctrl+e to explain`,
+			wantState: StateWaiting,
+			wantMode:  "",
+			wantDesc:  "",
+		},
+		{
 			name: "Unknown state",
 			content: `Some random output
 without any recognizable pattern`,


### PR DESCRIPTION
This pull request improves the status parsing logic in `claude/status.go` to better distinguish between user prompts and selection menus, and to correctly handle file change summary lines. It also adds new tests to verify these behaviors.

**Parsing enhancements:**

* Added a new regular expression `selectionMenuPattern` to detect selection menu lines like `❯ 1. Yes`, and updated the status parser to treat these as waiting for user input rather than as prompts. [[1]](diffhunk://#diff-f27063aa2b9048f2e13fdcd076a54db0a7814f24699b5614d3c658eb6257e612R50-R63) [[2]](diffhunk://#diff-f27063aa2b9048f2e13fdcd076a54db0a7814f24699b5614d3c658eb6257e612R140-R144)
* Added a new regular expression `fileChangesPattern` to identify file change summary lines (e.g., `4 files +42 -0`) and prevent them from being misclassified as prompts. [[1]](diffhunk://#diff-f27063aa2b9048f2e13fdcd076a54db0a7814f24699b5614d3c658eb6257e612R50-R63) [[2]](diffhunk://#diff-f27063aa2b9048f2e13fdcd076a54db0a7814f24699b5614d3c658eb6257e612L175-R199)

**Prompt detection improvements:**

* Updated the `isPromptLine` function to skip lines matching the new `fileChangesPattern` and to avoid treating selection menu markers as prompts.

**Testing improvements:**

* Added test cases to `status_test.go` for scenarios involving file change status lines and bash command confirmation dialogs with selection menus, ensuring correct state detection.