### PR TITLE
feat: add GitHub Copilot CLI support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,7 +59,7 @@ nfpms:
       - tcmux-linux
     homepage: https://github.com/k1LoW/tcmux
     maintainer: Ken'ichiro Oyama <k1lowxb@gmail.com>
-    description: "tcmux is a terminal and Claude Code mux viewer."
+    description: "tcmux is a terminal and coding agent mux viewer."
     license: MIT
     formats:
       - deb

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 make test
 
 # Run a single test
-go test -v ./claude -run TestParseStatus
+go test -v ./agent -run TestClaudeAgent_ParseStatus
 
 # Build the binary
 make build
@@ -26,18 +26,22 @@ make depsdev
 
 ## Architecture
 
-tcmux is a CLI tool that displays Claude Code instances running in tmux windows/sessions along with their status.
+tcmux is a CLI tool that displays coding agent instances (Claude Code, GitHub Copilot CLI) running in tmux windows/sessions along with their status.
 
 ### Core Components
 
 - **cmd/**: CLI commands using cobra
   - `root.go` - Root command with `--color` flag
-  - `lsw.go` - `list-windows` (alias: `lsw`) - Lists windows with Claude Code status
-  - `ls.go` - `list-sessions` (alias: `ls`) - Lists sessions with Claude Code stats
+  - `lsw.go` - `list-windows` (alias: `lsw`) - Lists windows with coding agent status
+  - `ls.go` - `list-sessions` (alias: `ls`) - Lists sessions with coding agent stats
 
-- **claude/**: Claude Code detection and status parsing
-  - `detector.go` - Detects Claude Code instances by checking pane title (✳ prefix or Braille spinner) and process name (`node` or `claude`)
-  - `status.go` - Parses pane content to determine status (Idle, Running, Waiting) using regex patterns for prompts, spinners, and permission dialogs
+- **agent/**: Coding agent detection and status parsing
+  - `agent.go` - `Detector` interface and `Detect()` function for agent detection
+  - `claude.go` - Claude Code detection (pane title with `✳` prefix or Braille spinner, process `claude` or `node`)
+  - `status_claude.go` - Claude Code status parsing
+  - `copilot.go` - Copilot CLI detection (process `copilot`)
+  - `status_copilot.go` - Copilot CLI status parsing
+  - `status.go` - Common status utilities
 
 - **tmux/**: tmux interaction via shell commands
   - `tmux.go` - Wraps `tmux list-panes`, `tmux list-sessions`, `tmux capture-pane`
@@ -50,13 +54,18 @@ tcmux is a CLI tool that displays Claude Code instances running in tmux windows/
 
 1. CLI command parses user format string and extracts tmux variables
 2. `tmux.ListPanes()` or `tmux.ListSessions()` fetches data from tmux
-3. For each pane, `claude.MayBeTitle()` + `claude.MayBeProcess()` detect Claude Code
-4. `tmux.CapturePane()` gets pane content, `claude.ParseStatus()` determines state
+3. For each pane, `agent.Detect()` checks if it's a coding agent (Claude Code or Copilot CLI)
+4. `tmux.CapturePane()` gets pane content, agent's `ParseStatus()` determines state
 5. `output.ExpandFormat()` generates final output with colors
 
 ### Status Detection
 
-Claude Code status is determined by regex matching the captured pane content:
+**Claude Code** status is determined by regex matching the captured pane content:
 - **Running**: Matches spinner symbols with time (e.g., `✻ Thinking… (1m 30s)`) or "esc to interrupt"
 - **Waiting**: Contains permission prompts like "Yes, allow once", "Run this command?", etc.
+- **Idle**: Prompt line starting with `❯`
+
+**GitHub Copilot CLI** status:
+- **Running**: Contains "Esc to cancel"
+- **Waiting**: Contains "Do you want to run this command?", "Confirm with number keys", etc.
 - **Idle**: Prompt line starting with `❯`

--- a/README.md
+++ b/README.md
@@ -1,30 +1,39 @@
 # tcmux [![build](https://github.com/k1LoW/tcmux/actions/workflows/ci.yml/badge.svg)](https://github.com/k1LoW/tcmux/actions/workflows/ci.yml) ![Coverage](https://raw.githubusercontent.com/k1LoW/octocovs/main/badges/k1LoW/tcmux/coverage.svg) ![Code to Test Ratio](https://raw.githubusercontent.com/k1LoW/octocovs/main/badges/k1LoW/tcmux/ratio.svg) ![Test Execution Time](https://raw.githubusercontent.com/k1LoW/octocovs/main/badges/k1LoW/tcmux/time.svg)
 
-`tcmux` is a **t**erminal and **C**laude Code **mux** viewer.
+`tcmux` is a **t**erminal and **c**oding agent **mux** viewer.
+
+Supports [Claude Code](https://claude.ai/code) and [GitHub Copilot CLI](https://github.com/github/copilot-cli).
 
 ## Usage
 
 ```console
-$ tcmux list-windows  # List Claude Code instances in tmux windows (alias: lsw)
+$ tcmux list-windows  # List coding agent instances in tmux windows (alias: lsw)
 0: editor (1 panes) ✻ Fix login bug [Idle]
 2: server (2 panes) ✻ Add API endpoint [Running (1m 30s)], ✻ Write tests [Idle]
 5: docs (1 panes) ✻ Update README [Idle]
-7: review (1 panes) ✻ Review PR [Waiting]
+7: review (1 panes) ⬢ Review PR [Waiting]
 
-$ tcmux list-windows -A  # Show all windows, not just Claude Code
+$ tcmux list-windows -A  # Show all windows, not just coding agents
 0: editor (1 panes) ✻ Fix login bug [Idle]
 1: shell (1 panes)
 2: server (2 panes) ✻ Add API endpoint [Running (1m 30s)], ✻ Write tests [Idle]
 3: logs (1 panes)
 4: htop (1 panes)
 5: docs (1 panes) ✻ Update README [Idle]
-7: review (1 panes) ✻ Review PR [Waiting]
+7: review (1 panes) ⬢ Review PR [Waiting]
 
-$ tcmux list-sessions  # List tmux sessions with Claude Code status (alias: ls)
+$ tcmux list-sessions  # List tmux sessions with coding agent status (alias: ls)
 dev: 7 windows (attached) - 3 Idle, 1 Running, 1 Waiting
 main: 2 windows - 1 Idle
 work: 1 window
 ```
+
+### Supported Agents
+
+| Agent | Icon | Detection |
+|-------|------|-----------|
+| Claude Code | ✻ | pane title starts with `✳` or Braille spinner, process is `claude` or `node` |
+| GitHub Copilot CLI | ⬢ | process is `copilot` |
 
 ### Options
 
@@ -32,7 +41,7 @@ work: 1 window
 
 | Option | Description |
 |--------|-------------|
-| `-A, --all-windows` | Show all windows, not just Claude Code. Use this when replacing `tmux list-windows` with tcmux |
+| `-A, --all-windows` | Show all windows, not just coding agents. Use this when replacing `tmux list-windows` with tcmux |
 | `-a, --all-sessions` | List windows from all sessions |
 | `-t, --target-session` | Specify target session |
 | `-F, --format` | Specify output format (tmux-compatible with tcmux extensions) |
@@ -49,9 +58,9 @@ tcmux supports all tmux format variables (e.g., `#{window_index}`, `#{window_nam
 
 | Variable | Description |
 |----------|-------------|
-| `#{agent_status}` | Claude Code status (context-dependent) |
+| `#{agent_status}` | Coding agent status (context-dependent) |
 
-- **list-windows:** `✻ Fix login bug [Idle], ✻ Add feature [Running (1m 30s, plan mode)]`
+- **list-windows:** `✻ Fix login bug [Idle], ⬢ Review PR [Running]`
 - **list-sessions:** `2 Idle, 1 Running`
 
 **Example:**
@@ -61,7 +70,7 @@ $ tcmux list-windows -F "#{window_index}:#{window_name} #{agent_status}"
 $ tcmux list-sessions -F "#{session_name}: #{agent_status}"
 ```
 
-### Recipe: Window switcher with Claude Code status
+### Recipe: Window switcher with coding agent status
 
 ![img](img/ss.png)
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1,0 +1,57 @@
+package agent
+
+// Type identifies the type of coding agent.
+type Type string
+
+const (
+	TypeClaude  Type = "claude"
+	TypeCopilot Type = "copilot"
+)
+
+// Status represents the status of a coding agent instance.
+type Status struct {
+	State       string // Idle, Running, Waiting, Unknown
+	Mode        string // plan mode, accept edits, or empty
+	Description string // Additional description (e.g., time elapsed)
+}
+
+// Status state constants
+const (
+	StateIdle    = "Idle"
+	StateRunning = "Running"
+	StateWaiting = "Waiting" // Agent is waiting for user input/selection
+	StateUnknown = "Unknown"
+)
+
+// Mode constants
+const (
+	ModePlan        = "plan mode"
+	ModeAcceptEdits = "accept edits"
+)
+
+// Detector defines the interface for detecting and parsing coding agents.
+type Detector interface {
+	Type() Type
+	Icon() string
+	MayBeTitle(title string) bool
+	MayBeProcess(currentCommand string) bool
+	ExtractSummary(title string) string
+	ParseStatus(content string) Status
+}
+
+// All registered detectors
+var detectors = []Detector{
+	&ClaudeAgent{},
+	&CopilotAgent{},
+}
+
+// Detect checks if a pane might be running a coding agent.
+// Returns the detected agent or nil if no agent is detected.
+func Detect(title, currentCommand string) Detector {
+	for _, d := range detectors {
+		if d.MayBeTitle(title) && d.MayBeProcess(currentCommand) {
+			return d
+		}
+	}
+	return nil
+}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,0 +1,93 @@
+package agent
+
+import "testing"
+
+func TestDetect(t *testing.T) {
+	tests := []struct {
+		name           string
+		title          string
+		currentCommand string
+		wantType       Type
+		wantNil        bool
+	}{
+		{
+			name:           "Claude Code with node",
+			title:          "✳ Task summary",
+			currentCommand: "node",
+			wantType:       TypeClaude,
+		},
+		{
+			name:           "Claude Code with claude binary",
+			title:          "✳ Task summary",
+			currentCommand: "claude",
+			wantType:       TypeClaude,
+		},
+		{
+			name:           "Claude Code with Braille spinner",
+			title:          "⠂ Task summary",
+			currentCommand: "node",
+			wantType:       TypeClaude,
+		},
+		{
+			name:           "Copilot CLI with default title",
+			title:          "GitHub Copilot",
+			currentCommand: "copilot",
+			wantType:       TypeCopilot,
+		},
+		{
+			name:           "Copilot CLI with custom title",
+			title:          "🤖 Detailed code review",
+			currentCommand: "copilot",
+			wantType:       TypeCopilot,
+		},
+		{
+			name:           "Normal shell",
+			title:          "zsh",
+			currentCommand: "zsh",
+			wantNil:        true,
+		},
+		{
+			name:           "Claude title but wrong process",
+			title:          "✳ Task summary",
+			currentCommand: "zsh",
+			wantNil:        true,
+		},
+		{
+			name:           "Copilot title but wrong process",
+			title:          "GitHub Copilot",
+			currentCommand: "zsh",
+			wantNil:        true,
+		},
+		{
+			name:           "Node process with non-Claude title is not detected",
+			title:          "some random title",
+			currentCommand: "node",
+			wantNil:        true,
+		},
+		{
+			name:           "Empty title",
+			title:          "",
+			currentCommand: "node",
+			wantNil:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Detect(tt.title, tt.currentCommand)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("Detect(%q, %q) = %v, want nil", tt.title, tt.currentCommand, got.Type())
+				}
+				return
+			}
+			if got == nil {
+				t.Errorf("Detect(%q, %q) = nil, want %v", tt.title, tt.currentCommand, tt.wantType)
+				return
+			}
+			if got.Type() != tt.wantType {
+				t.Errorf("Detect(%q, %q).Type() = %v, want %v", tt.title, tt.currentCommand, got.Type(), tt.wantType)
+			}
+		})
+	}
+}

--- a/agent/claude.go
+++ b/agent/claude.go
@@ -1,27 +1,26 @@
-package claude
+package agent
 
 import (
 	"strings"
 	"unicode"
 )
 
-// Claude Code title prefixes
-const (
-	claudePrefixIdle = "✳" // Idle state
-)
+// Claude Code title prefix
+const claudePrefixIdle = "✳" // Idle state
 
-// ClaudePane represents a Claude Code instance running in a tmux pane.
-type ClaudePane struct {
-	Session    string
-	Window     string
-	WindowName string
-	Summary    string
-	Status     Status
+// ClaudeAgent detects and parses Claude Code instances.
+type ClaudeAgent struct{}
+
+func (a *ClaudeAgent) Type() Type {
+	return TypeClaude
+}
+
+func (a *ClaudeAgent) Icon() string {
+	return "✻"
 }
 
 // MayBeTitle checks if the pane title may indicate a Claude Code instance.
-// Use together with MayBeProcess(currentCommand) to confirm.
-func MayBeTitle(title string) bool {
+func (a *ClaudeAgent) MayBeTitle(title string) bool {
 	if strings.HasPrefix(title, claudePrefixIdle) {
 		return true
 	}
@@ -42,13 +41,12 @@ func isBraillePattern(r rune) bool {
 
 // MayBeProcess checks if the current command may be a Claude Code process.
 // Claude Code runs as "node" (npm install) or "claude" (brew install --cask claude-code).
-// Use together with MayBeTitle(title) to confirm.
-func MayBeProcess(currentCommand string) bool {
+func (a *ClaudeAgent) MayBeProcess(currentCommand string) bool {
 	return currentCommand == "node" || currentCommand == "claude"
 }
 
 // ExtractSummary extracts the task summary from the pane title.
-func ExtractSummary(title string) string {
+func (a *ClaudeAgent) ExtractSummary(title string) string {
 	// Remove the "✳ " prefix
 	if strings.HasPrefix(title, claudePrefixIdle) {
 		summary := strings.TrimPrefix(title, claudePrefixIdle)
@@ -63,4 +61,9 @@ func ExtractSummary(title string) string {
 		}
 	}
 	return strings.TrimSpace(title)
+}
+
+// ParseStatus parses the pane content and determines the Claude Code status.
+func (a *ClaudeAgent) ParseStatus(content string) Status {
+	return parseClaudeStatus(content)
 }

--- a/agent/claude_test.go
+++ b/agent/claude_test.go
@@ -1,8 +1,9 @@
-package claude
+package agent
 
 import "testing"
 
-func TestMayBeTitle(t *testing.T) {
+func TestClaudeAgent_MayBeTitle(t *testing.T) {
+	agent := &ClaudeAgent{}
 	tests := []struct {
 		name  string
 		title string
@@ -17,18 +18,21 @@ func TestMayBeTitle(t *testing.T) {
 		{"Normal shell", "zsh", false},
 		{"Empty title", "", false},
 		{"Similar but not Claude", "* Task", false},
+		{"Copilot title", "GitHub Copilot", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := MayBeTitle(tt.title)
+			got := agent.MayBeTitle(tt.title)
 			if got != tt.want {
-				t.Errorf("MayBeTitle(%q) = %v, want %v", tt.title, got, tt.want)			}
+				t.Errorf("ClaudeAgent.MayBeTitle(%q) = %v, want %v", tt.title, got, tt.want)
+			}
 		})
 	}
 }
 
-func TestMayBeProcess(t *testing.T) {
+func TestClaudeAgent_MayBeProcess(t *testing.T) {
+	agent := &ClaudeAgent{}
 	tests := []struct {
 		name           string
 		currentCommand string
@@ -40,18 +44,21 @@ func TestMayBeProcess(t *testing.T) {
 		{"Bash shell", "bash", false},
 		{"Emacs", "emacs-30.1", false},
 		{"Empty", "", false},
+		{"Copilot binary", "copilot", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := MayBeProcess(tt.currentCommand)
+			got := agent.MayBeProcess(tt.currentCommand)
 			if got != tt.want {
-				t.Errorf("MayBeProcess(%q) = %v, want %v", tt.currentCommand, got, tt.want)			}
+				t.Errorf("ClaudeAgent.MayBeProcess(%q) = %v, want %v", tt.currentCommand, got, tt.want)
+			}
 		})
 	}
 }
 
-func TestExtractSummary(t *testing.T) {
+func TestClaudeAgent_ExtractSummary(t *testing.T) {
+	agent := &ClaudeAgent{}
 	tests := []struct {
 		name  string
 		title string
@@ -66,9 +73,10 @@ func TestExtractSummary(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ExtractSummary(tt.title)
+			got := agent.ExtractSummary(tt.title)
 			if got != tt.want {
-				t.Errorf("ExtractSummary(%q) = %q, want %q", tt.title, got, tt.want)			}
+				t.Errorf("ClaudeAgent.ExtractSummary(%q) = %q, want %q", tt.title, got, tt.want)
+			}
 		})
 	}
 }

--- a/agent/copilot.go
+++ b/agent/copilot.go
@@ -1,0 +1,52 @@
+package agent
+
+import "strings"
+
+// CopilotAgent detects and parses GitHub Copilot CLI instances.
+type CopilotAgent struct{}
+
+func (a *CopilotAgent) Type() Type {
+	return TypeCopilot
+}
+
+func (a *CopilotAgent) Icon() string {
+	return "⬢"
+}
+
+// MayBeTitle checks if the pane title may indicate a Copilot CLI instance.
+// For Copilot CLI, we primarily rely on process name detection.
+// Title check is permissive - any title is accepted when process is "copilot".
+func (a *CopilotAgent) MayBeTitle(title string) bool {
+	// Copilot CLI can have various titles, so we accept any non-empty title
+	// The actual detection is done by MayBeProcess
+	return true
+}
+
+// MayBeProcess checks if the current command may be a Copilot CLI process.
+// Copilot CLI runs as "copilot".
+func (a *CopilotAgent) MayBeProcess(currentCommand string) bool {
+	return currentCommand == "copilot"
+}
+
+// ExtractSummary extracts the task summary from the pane title.
+func (a *CopilotAgent) ExtractSummary(title string) string {
+	// Remove common emoji prefixes
+	title = strings.TrimSpace(title)
+	if len(title) > 0 {
+		r := []rune(title)
+		// Skip leading emoji (if any)
+		if len(r) > 0 && r[0] > 0x1F000 {
+			title = strings.TrimSpace(string(r[1:]))
+		}
+	}
+	// "GitHub Copilot" is the default title, return empty
+	if title == "GitHub Copilot" {
+		return ""
+	}
+	return title
+}
+
+// ParseStatus parses the pane content and determines the Copilot CLI status.
+func (a *CopilotAgent) ParseStatus(content string) Status {
+	return parseCopilotStatus(content)
+}

--- a/agent/copilot_test.go
+++ b/agent/copilot_test.go
@@ -1,0 +1,180 @@
+package agent
+
+import "testing"
+
+func TestCopilotAgent_MayBeTitle(t *testing.T) {
+	agent := &CopilotAgent{}
+	tests := []struct {
+		name  string
+		title string
+		want  bool
+	}{
+		{"Copilot CLI default title", "GitHub Copilot", true},
+		{"Copilot CLI custom title", "🤖 Detailed code review", true},
+		{"Any title is accepted", "zsh", true}, // Title check is permissive
+		{"Empty title", "", true},              // Detection relies on process name
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := agent.MayBeTitle(tt.title)
+			if got != tt.want {
+				t.Errorf("CopilotAgent.MayBeTitle(%q) = %v, want %v", tt.title, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCopilotAgent_MayBeProcess(t *testing.T) {
+	agent := &CopilotAgent{}
+	tests := []struct {
+		name           string
+		currentCommand string
+		want           bool
+	}{
+		{"Copilot binary", "copilot", true},
+		{"Node process", "node", false}, // node alone is not enough, could be Claude Code
+		{"Claude binary", "claude", false},
+		{"Zsh shell", "zsh", false},
+		{"Bash shell", "bash", false},
+		{"Empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := agent.MayBeProcess(tt.currentCommand)
+			if got != tt.want {
+				t.Errorf("CopilotAgent.MayBeProcess(%q) = %v, want %v", tt.currentCommand, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCopilotAgent_ExtractSummary(t *testing.T) {
+	agent := &CopilotAgent{}
+	tests := []struct {
+		name  string
+		title string
+		want  string
+	}{
+		{"Default title", "GitHub Copilot", ""},
+		{"Custom title", "Some other title", "Some other title"},
+		{"Title with emoji prefix", "🤖 Detailed code review", "Detailed code review"},
+		{"Title with robot emoji", "🤖 Review PR", "Review PR"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := agent.ExtractSummary(tt.title)
+			if got != tt.want {
+				t.Errorf("CopilotAgent.ExtractSummary(%q) = %q, want %q", tt.title, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCopilotAgent_ParseStatus(t *testing.T) {
+	agent := &CopilotAgent{}
+	tests := []struct {
+		name      string
+		content   string
+		wantState string
+	}{
+		{
+			name: "Running with Esc to cancel in parentheses",
+			content: `Thinking...
+∙ Processing (Esc to cancel · 100 B)`,
+			wantState: StateRunning,
+		},
+		{
+			name: "Running with middle dot spinner and Esc to cancel",
+			content: `● Check git status
+  $ git --no-pager status
+  └ 21 lines...
+
+● Show git diff
+  $ git --no-pager diff
+  └ 8 lines...
+
+∙ Reviewing git diff (Esc to cancel · 492 B)
+
+ ~/src/github.com/k1LoW/tcmux/.worktrees/copilot[⎇ copilot*]                                                                                                        claude-sonnet-4.5 (1x)
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+❯  Type @ to mention files or / for commands
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ shift+tab cycle mode · ctrl+d enqueue`,
+			wantState: StateRunning,
+		},
+		{
+			name: "Waiting with Asking user",
+			content: `What would you like to do?
+Asking user: Please select an option`,
+			wantState: StateWaiting,
+		},
+		{
+			name: "Waiting with selection prompt",
+			content: `Select an action:
+Use ↑↓ or number keys to select`,
+			wantState: StateWaiting,
+		},
+		{
+			name: "Waiting with command confirmation dialog",
+			content: `● Read agent/status_copilot.go
+  └ 86 lines read
+
+○ Check if README or CLAUDE.md were updated
+  $ git --no-pager diff --unified=0 README.md CLAUDE.md 2>/dev/null || echo "No changes"
+
+╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ Check if README or CLAUDE.md were updated                                                                                                                                               │
+│                                                                                                                                                                                         │
+│ Do you want to run this command?                                                                                                                                                        │
+│                                                                                                                                                                                         │
+│ ❯ 1. Yes                                                                                                                                                                                │
+│   2. No, and tell Copilot what to do differently (Esc to stop)                                                                                                                          │
+│                                                                                                                                                                                         │
+│ Confirm with number keys or ↑↓ keys and Enter, Cancel with Esc                                                                                                                          │
+╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯`,
+			wantState: StateWaiting,
+		},
+		{
+			name: "Idle with prompt",
+			content: `Previous output
+❯ `,
+			wantState: StateIdle,
+		},
+		{
+			name: "Idle - quoted Esc to cancel in documentation should not match",
+			content: `  - **Running**: Contains "Esc to cancel"
+  - **Waiting**: Contains prompt dialogs
+  - **Idle**: Prompt line starting with ❯
+
+ ~/src/github.com/k1LoW/tcmux
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+❯  Type @ to mention files or / for commands
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ shift+tab cycle mode`,
+			wantState: StateIdle,
+		},
+		{
+			name: "Unknown state",
+			content: `Some random output
+without any recognizable pattern`,
+			wantState: StateUnknown,
+		},
+		{
+			name:      "Empty content",
+			content:   "",
+			wantState: StateUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := agent.ParseStatus(tt.content)
+			if got.State != tt.wantState {
+				t.Errorf("CopilotAgent.ParseStatus().State = %q, want %q", got.State, tt.wantState)
+			}
+		})
+	}
+}

--- a/agent/status.go
+++ b/agent/status.go
@@ -1,0 +1,32 @@
+package agent
+
+import "strings"
+
+// lastNonEmptyLines returns the last n non-empty lines.
+// It skips lines that are only separators (─, ═, etc.).
+func lastNonEmptyLines(lines []string, n int) []string {
+	var result []string
+	for i := len(lines) - 1; i >= 0 && len(result) < n; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		// Skip separator lines (lines consisting only of box-drawing characters)
+		if isSeparatorLine(line) {
+			continue
+		}
+		result = append([]string{lines[i]}, result...)
+	}
+	return result
+}
+
+// isSeparatorLine checks if a line consists only of box-drawing characters.
+func isSeparatorLine(line string) bool {
+	for _, r := range line {
+		// Box-drawing characters range: U+2500 to U+257F
+		if r < 0x2500 || r > 0x257F {
+			return false
+		}
+	}
+	return true
+}

--- a/agent/status_claude_test.go
+++ b/agent/status_claude_test.go
@@ -1,14 +1,15 @@
-package claude
+package agent
 
 import "testing"
 
-func TestParseStatus(t *testing.T) {
+func TestClaudeAgent_ParseStatus(t *testing.T) {
+	agent := &ClaudeAgent{}
 	tests := []struct {
-		name        string
-		content     string
-		wantState   string
-		wantMode    string
-		wantDesc    string
+		name      string
+		content   string
+		wantState string
+		wantMode  string
+		wantDesc  string
 	}{
 		{
 			name: "Idle with prompt only",
@@ -364,8 +365,8 @@ without any recognizable pattern`,
 			wantDesc:  "",
 		},
 		{
-			name: "Empty content",
-			content: "",
+			name:      "Empty content",
+			content:   "",
 			wantState: StateUnknown,
 			wantMode:  "",
 			wantDesc:  "",
@@ -374,13 +375,16 @@ without any recognizable pattern`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ParseStatus(tt.content)
+			got := agent.ParseStatus(tt.content)
 			if got.State != tt.wantState {
-				t.Errorf("ParseStatus().State = %q, want %q", got.State, tt.wantState)			}
+				t.Errorf("ClaudeAgent.ParseStatus().State = %q, want %q", got.State, tt.wantState)
+			}
 			if got.Mode != tt.wantMode {
-				t.Errorf("ParseStatus().Mode = %q, want %q", got.Mode, tt.wantMode)			}
+				t.Errorf("ClaudeAgent.ParseStatus().Mode = %q, want %q", got.Mode, tt.wantMode)
+			}
 			if got.Description != tt.wantDesc {
-				t.Errorf("ParseStatus().Description = %q, want %q", got.Description, tt.wantDesc)			}
+				t.Errorf("ClaudeAgent.ParseStatus().Description = %q, want %q", got.Description, tt.wantDesc)
+			}
 		})
 	}
 }

--- a/agent/status_copilot.go
+++ b/agent/status_copilot.go
@@ -1,0 +1,88 @@
+package agent
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Copilot CLI status indicators
+var (
+	// Running pattern: "(Esc to cancel" at end of a status line (not quoted text)
+	// Format: ∙ Action... (Esc to cancel · 492 B)
+	copilotRunningPattern = regexp.MustCompile(`\(Esc to cancel`)
+
+	// Waiting patterns: Copilot is asking for user input
+	copilotWaitingPatterns = []string{
+		"Asking user:",
+		"Use ↑↓ or number keys to select",
+		"Do you want to run this command?",
+		"Confirm with number keys",
+		"Cancel with Esc",
+	}
+)
+
+// parseCopilotStatus parses the pane content and determines the Copilot CLI status.
+func parseCopilotStatus(content string) Status {
+	lines := strings.Split(content, "\n")
+
+	// Check the last few lines for status indicators
+	lastLines := lastNonEmptyLines(lines, 30)
+	combined := strings.Join(lastLines, "\n")
+
+	status := Status{
+		State:       StateUnknown,
+		Mode:        "",
+		Description: "",
+	}
+
+	// Check for running state: "(Esc to cancel" indicates Copilot is processing
+	// Must be in parentheses to avoid matching quoted text in documentation
+	if copilotRunningPattern.MatchString(combined) {
+		status.State = StateRunning
+		return status
+	}
+
+	// Check for idle state first: if the last meaningful line is a prompt,
+	// then the agent is idle (even if there are dialogs/overlays or quoted text above)
+	if isCopilotPromptLine(lines) {
+		status.State = StateIdle
+		return status
+	}
+
+	// Check for waiting state: Copilot is asking for user input
+	for _, pattern := range copilotWaitingPatterns {
+		if strings.Contains(combined, pattern) {
+			status.State = StateWaiting
+			return status
+		}
+	}
+
+	return status
+}
+
+// isCopilotPromptLine checks if the last non-empty, non-separator line is a prompt.
+func isCopilotPromptLine(lines []string) bool {
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		if isSeparatorLine(line) {
+			continue
+		}
+		// Skip common footer lines (same patterns as Claude Code)
+		if strings.Contains(line, "? for shortcuts") ||
+			strings.Contains(line, "ctrl+") ||
+			strings.Contains(line, "shift+") ||
+			strings.Contains(line, "Remaining requests:") {
+			continue
+		}
+		// Copilot CLI prompt: "❯" (same as Claude Code)
+		if strings.HasPrefix(line, "❯") {
+			return true
+		}
+		// Not a prompt line
+		return false
+	}
+	return false
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,8 +11,8 @@ var colorMode string
 
 var rootCmd = &cobra.Command{
 	Use:   "tcmux",
-	Short: "terminal and Claude Code mux viewer",
-	Long:  `tcmux is a terminal and Claude Code mux viewer.`,
+	Short: "terminal and coding agent mux viewer",
+	Long:  `tcmux is a terminal and coding agent mux viewer (supports Claude Code, Copilot CLI).`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return output.SetColorMode(colorMode)
 	},

--- a/output/color.go
+++ b/output/color.go
@@ -21,6 +21,9 @@ var (
 
 	// Claude Code theme color (for branding/separators)
 	claudeThemeColor termenv.Color
+
+	// Copilot CLI theme color
+	copilotThemeColor termenv.Color
 )
 
 func init() {
@@ -29,12 +32,13 @@ func init() {
 
 func initOutput(o *termenv.Output) {
 	output = o
-	idleColor = output.Color("#00B359")        // Green
-	runningColor = output.Color("#E5A000")     // Orange/Yellow
-	waitingColor = output.Color("#5CC8FF")     // Cyan/Light blue - awaiting input
-	unknownColor = output.Color("#666666")     // Dark gray
-	modeColor = output.Color("#B366FF")        // Purple/Magenta
-	claudeThemeColor = output.Color("#E5A000") // Claude Code orange
+	idleColor = output.Color("#00B359")         // Green
+	runningColor = output.Color("#E5A000")      // Orange/Yellow
+	waitingColor = output.Color("#5CC8FF")      // Cyan/Light blue - awaiting input
+	unknownColor = output.Color("#666666")      // Dark gray
+	modeColor = output.Color("#B366FF")         // Purple/Magenta
+	claudeThemeColor = output.Color("#E5A000")  // Claude Code orange
+	copilotThemeColor = output.Color("#8534F3") // Copilot purple (official brand color)
 }
 
 // SetColorMode sets the color output mode: always, never, or auto.

--- a/tmux/tmux.go
+++ b/tmux/tmux.go
@@ -34,7 +34,7 @@ func CapturePane(ctx context.Context, paneID string) (string, error) {
 	return string(out), nil
 }
 
-// InternalPaneVars are tmux variables required internally for Claude Code detection.
+// InternalPaneVars are tmux variables required internally for coding agent detection.
 var InternalPaneVars = []string{
 	"session_name",
 	"window_index",


### PR DESCRIPTION
ref: #5 

This pull request introduces support for multiple coding agents (Claude Code and GitHub Copilot CLI) in `tcmux`, generalizing the architecture and user interface from being Claude-specific to supporting a broader set of coding agents. The codebase is refactored to use a new agent detection interface, and documentation is updated throughout to reflect these enhancements.

**Agent detection and architecture refactoring:**

* Introduced a new `agent` package with a generic `Detector` interface and implementations for both Claude Code (`ClaudeAgent`) and GitHub Copilot CLI (`CopilotAgent`). The `Detect()` function now determines the agent type based on pane title and process. (`agent/agent.go`, `agent/claude.go`, `agent/copilot.go`) [[1]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bR1-R57) [[2]](diffhunk://#diff-aa3c0a3ddf184f297c034ffb8d73b850781abf4d09e269b1797d74115755653cL1-R23) [[3]](diffhunk://#diff-752609b910bf7521aedb658a3b2ddef2837e8708c71ede5e5b9973b966da201aR1-R54)
* Added comprehensive unit tests for the agent detection logic, ensuring correct identification of Claude Code, Copilot CLI, and non-agent panes. (`agent/agent_test.go`, `agent/claude_test.go`) [[1]](diffhunk://#diff-e12d66df9a328a0b4b4e61abbde9a65eb60a4c8a6a8ca9249a455f173007ac89R1-R93) [[2]](diffhunk://#diff-0cff2d30ff534b647b3ed7d4ec545837da99de8e512880dcd88e76f76da7b6aeL1-R6)

**Documentation and user interface updates:**

* Updated `README.md` and `CLAUDE.md` to describe support for both Claude Code and Copilot CLI, including user-facing changes such as new icons, agent terminology, and detection logic. Added a "Supported Agents" section and updated usage examples and options to refer to "coding agents" instead of just Claude Code. (`README.md`, `CLAUDE.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R44) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L29-R44)
* Updated status descriptions and output samples to reflect the new agent-agnostic approach, including Copilot CLI status detection and formatting. (`README.md`, `CLAUDE.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-R63) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L53-R71)

**Packaging and metadata:**

* Updated the project description in `.goreleaser.yml` to reflect the broader scope as a "terminal and coding agent mux viewer."

These changes collectively make `tcmux` a more extensible tool, ready to support additional coding agents in the future.