### PR TITLE
feat: add `stats` command for aggregated agent statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ $ tcmux list-sessions  # List tmux sessions with coding agent status (alias: ls)
 dev: 7 windows (attached) - 3 Idle, 1 Running, 1 Waiting
 main: 2 windows - 1 Idle
 work: 1 window
+
+$ tcmux stats  # Show total coding agent stats across all sessions
+I:4 R:1 W:1
+
+$ tcmux stats -F "#{agent_status}"
+4 Idle, 1 Running, 1 Waiting
 ```
 
 ### Supported Agents
@@ -45,6 +51,12 @@ work: 1 window
 | `-a, --all-sessions` | List windows from all sessions |
 | `-t, --target-session` | Specify target session |
 | `-F, --format` | Specify output format (tmux-compatible with tcmux extensions) |
+
+**stats:**
+
+| Option | Description |
+|--------|-------------|
+| `-F, --format` | Specify output format (default: `I:#{total_idle} R:#{total_running} W:#{total_waiting}`) |
 
 **Global:**
 
@@ -68,6 +80,7 @@ tcmux supports all tmux format variables (e.g., `#{window_index}`, `#{window_nam
 ```console
 $ tcmux list-windows -F "#{window_index}:#{window_name} #{agent_status}"
 $ tcmux list-sessions -F "#{session_name}: #{agent_status}"
+$ tcmux stats -F "💤#{total_idle} 🏃#{total_running} ⏳#{total_waiting}"
 ```
 
 ### Recipe: Window switcher with coding agent status

--- a/README.md
+++ b/README.md
@@ -71,9 +71,14 @@ tcmux supports all tmux format variables (e.g., `#{window_index}`, `#{window_nam
 | Variable | Description |
 |----------|-------------|
 | `#{agent_status}` | Coding agent status (context-dependent) |
+| `#{total_idle}` | Total idle count (stats only) |
+| `#{total_running}` | Total running count (stats only) |
+| `#{total_waiting}` | Total waiting count (stats only) |
+| `#{total_agents}` | Total agent count (stats only) |
 
 - **list-windows:** `✻ Fix login bug [Idle], ⬢ Review PR [Running]`
 - **list-sessions:** `2 Idle, 1 Running`
+- **stats:** `4 Idle, 1 Running, 1 Waiting`
 
 **Example:**
 

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/k1LoW/tcmux/agent"
+	"github.com/k1LoW/tcmux/output"
+	"github.com/k1LoW/tcmux/tmux"
+	"github.com/spf13/cobra"
+)
+
+const defaultStatsFormat = "I:#{total_idle} R:#{total_running} W:#{total_waiting}"
+
+var statsFormat string
+
+var statsCmd = &cobra.Command{
+	Use:   "stats",
+	Short: "Show total coding agent stats across all sessions",
+	Long:  `Show aggregated coding agent statistics (Claude Code, Copilot CLI) across all tmux sessions.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
+		// Get all panes
+		paneFormat := buildTmuxFormat(tmux.InternalPaneVars)
+		panes, err := tmux.ListPanes(ctx, paneFormat, tmux.InternalPaneVars, tmux.ListPanesOptions{AllSessions: true})
+		if err != nil {
+			return fmt.Errorf("failed to list tmux panes: %w", err)
+		}
+
+		// Count agent states
+		var totalStats output.TotalStatsContext
+		for _, pane := range panes {
+			detectedAgent := agent.Detect(pane.Vars["pane_title"], pane.Vars["pane_current_command"])
+			if detectedAgent == nil {
+				continue
+			}
+
+			content, err := tmux.CapturePane(ctx, pane.Vars["pane_id"])
+			if err != nil {
+				continue
+			}
+
+			status := detectedAgent.ParseStatus(content)
+			if status.State == agent.StateUnknown {
+				continue
+			}
+
+			switch status.State {
+			case agent.StateIdle:
+				totalStats.IdleCount++
+			case agent.StateRunning:
+				totalStats.RunningCount++
+			case agent.StateWaiting:
+				totalStats.WaitingCount++
+			}
+		}
+
+		// Output
+		format := statsFormat
+		if format == "" {
+			format = defaultStatsFormat
+		}
+
+		line := output.ExpandStatsFormat(format, &totalStats)
+		fmt.Println(line)
+
+		return nil
+	},
+}
+
+func init() {
+	statsCmd.Flags().StringVarP(&statsFormat, "format", "F", "", "Specify output format (use #{total_idle}, #{total_running}, #{total_waiting}, #{total_agents}, #{agent_status})")
+	rootCmd.AddCommand(statsCmd)
+}

--- a/output/format.go
+++ b/output/format.go
@@ -11,7 +11,11 @@ import (
 
 // tcmux custom format variables
 const (
-	VarAgentStatus = "agent_status" // Coding agent status (context-dependent output)
+	VarAgentStatus  = "agent_status"  // Coding agent status (context-dependent output)
+	VarTotalIdle    = "total_idle"    // Total idle count
+	VarTotalRunning = "total_running" // Total running count
+	VarTotalWaiting = "total_waiting" // Total waiting count
+	VarTotalAgents  = "total_agents"  // Total agent count
 )
 
 var (
@@ -20,7 +24,11 @@ var (
 
 	// tcmux custom variables
 	tcmuxVars = map[string]bool{
-		VarAgentStatus: true,
+		VarAgentStatus:  true,
+		VarTotalIdle:    true,
+		VarTotalRunning: true,
+		VarTotalWaiting: true,
+		VarTotalAgents:  true,
 	}
 )
 
@@ -47,6 +55,15 @@ type SessionFormatContext struct {
 	TmuxVars map[string]string
 
 	// Coding agent stats
+	IdleCount    int
+	RunningCount int
+	WaitingCount int
+}
+
+// TotalStatsContext holds data for total stats format expansion.
+// Note: TmuxVars is not included because stats aggregates across all sessions,
+// so there is no specific session/window context to reference.
+type TotalStatsContext struct {
 	IdleCount    int
 	RunningCount int
 	WaitingCount int
@@ -115,6 +132,32 @@ func ExpandSessionFormat(format string, ctx *SessionFormatContext) string {
 			if val, ok := ctx.TmuxVars[varName]; ok {
 				return val
 			}
+			return match
+		}
+	})
+
+	return result
+}
+
+// ExpandStatsFormat expands a format string for total stats.
+func ExpandStatsFormat(format string, ctx *TotalStatsContext) string {
+	result := format
+
+	result = formatVarPattern.ReplaceAllStringFunc(result, func(match string) string {
+		varName := match[2 : len(match)-1]
+
+		switch varName {
+		case VarAgentStatus:
+			return formatAgentStats(ctx.IdleCount, ctx.RunningCount, ctx.WaitingCount)
+		case VarTotalIdle:
+			return fmt.Sprintf("%d", ctx.IdleCount)
+		case VarTotalRunning:
+			return fmt.Sprintf("%d", ctx.RunningCount)
+		case VarTotalWaiting:
+			return fmt.Sprintf("%d", ctx.WaitingCount)
+		case VarTotalAgents:
+			return fmt.Sprintf("%d", ctx.IdleCount+ctx.RunningCount+ctx.WaitingCount)
+		default:
 			return match
 		}
 	})

--- a/output/format_test.go
+++ b/output/format_test.go
@@ -249,3 +249,102 @@ func TestExpandSessionFormat(t *testing.T) {
 		})
 	}
 }
+
+func TestExpandStatsFormat(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		ctx    *TotalStatsContext
+		want   string
+	}{
+		{
+			name:   "Expand total_idle",
+			format: "#{total_idle}",
+			ctx: &TotalStatsContext{
+				IdleCount:    3,
+				RunningCount: 2,
+				WaitingCount: 1,
+			},
+			want: "3",
+		},
+		{
+			name:   "Expand total_running",
+			format: "#{total_running}",
+			ctx: &TotalStatsContext{
+				IdleCount:    3,
+				RunningCount: 2,
+				WaitingCount: 1,
+			},
+			want: "2",
+		},
+		{
+			name:   "Expand total_waiting",
+			format: "#{total_waiting}",
+			ctx: &TotalStatsContext{
+				IdleCount:    3,
+				RunningCount: 2,
+				WaitingCount: 1,
+			},
+			want: "1",
+		},
+		{
+			name:   "Expand total_agents",
+			format: "#{total_agents}",
+			ctx: &TotalStatsContext{
+				IdleCount:    3,
+				RunningCount: 2,
+				WaitingCount: 1,
+			},
+			want: "6",
+		},
+		{
+			name:   "Expand agent_status",
+			format: "#{agent_status}",
+			ctx: &TotalStatsContext{
+				IdleCount:    3,
+				RunningCount: 2,
+				WaitingCount: 1,
+			},
+			want: "3 Idle, 2 Running, 1 Waiting",
+		},
+		{
+			name:   "Custom format with multiple variables",
+			format: "W:#{total_waiting} R:#{total_running} I:#{total_idle}",
+			ctx: &TotalStatsContext{
+				IdleCount:    3,
+				RunningCount: 2,
+				WaitingCount: 1,
+			},
+			want: "W:1 R:2 I:3",
+		},
+		{
+			name:   "Zero counts",
+			format: "W:#{total_waiting} R:#{total_running} I:#{total_idle}",
+			ctx: &TotalStatsContext{
+				IdleCount:    0,
+				RunningCount: 0,
+				WaitingCount: 0,
+			},
+			want: "W:0 R:0 I:0",
+		},
+		{
+			name:   "Empty agent_status when no agents",
+			format: "#{agent_status}",
+			ctx: &TotalStatsContext{
+				IdleCount:    0,
+				RunningCount: 0,
+				WaitingCount: 0,
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExpandStatsFormat(tt.format, tt.ctx)
+			if got != tt.want {
+				t.Errorf("ExpandStatsFormat() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add a new `stats` command that aggregates coding agent statistics across all tmux sessions, making it easy to display total agent counts in tmux status bar.

- Add `stats` command that counts agents in Idle/Running/Waiting states across all sessions
- Support format variables: `#{total_idle}`, `#{total_running}`, `#{total_waiting}`, `#{total_agents}`, `#{agent_status}`
- Default format: `I:#{total_idle} R:#{total_running} W:#{total_waiting}` (compact for status bar use)

### Use Case

This is useful for displaying aggregated agent status in tmux status bar header:

```bash
# In .tmux.conf
set -g status-right "#(tcmux stats)"
# Output: I:4 R:1 W:1
```