### PR TITLE
feat: add Codex CLI support to tcmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ work: 1 window
 |-------|------|-----------|
 | Claude Code | ✻ | pane title starts with `✳` or Braille spinner, process is `claude` or `node` |
 | GitHub Copilot CLI | ⬢ | process is `copilot` |
-| Codex | ❂ | process is `codex` |
+| Codex | ❂ | process name starts with `codex` (e.g. `codex`, `codex-aarch64-a`) |
 
 ### Options
 
@@ -63,7 +63,7 @@ tcmux supports all tmux format variables (e.g., `#{window_index}`, `#{window_nam
 |----------|-------------|
 | `#{agent_status}` | Coding agent status (context-dependent) |
 
-- **list-windows:** `✻ Fix login bug [Idle], ⬢ Review PR [Running]`
+- **list-windows:** `✻ Fix login bug [Idle], ⬢ Review PR [Running], ❂ Refactor parser [Running (plan mode)]`
 - **list-sessions:** `2 Idle, 1 Running`
 
 **Example:**

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `tcmux` is a **t**erminal and **c**oding agent **mux** viewer.
 
-Supports [Claude Code](https://claude.ai/code) and [GitHub Copilot CLI](https://github.com/github/copilot-cli).
+Supports [Claude Code](https://claude.ai/code), [GitHub Copilot CLI](https://github.com/github/copilot-cli), and Codex.
 
 ## Usage
 
@@ -12,6 +12,7 @@ $ tcmux list-windows  # List coding agent instances in tmux windows (alias: lsw)
 2: server (2 panes) ✻ Add API endpoint [Running (1m 30s)], ✻ Write tests [Idle]
 5: docs (1 panes) ✻ Update README [Idle]
 7: review (1 panes) ⬢ Review PR [Waiting]
+8: codex (1 panes) ❂ Refactor parser [Running]
 
 $ tcmux list-windows -A  # Show all windows, not just coding agents
 0: editor (1 panes) ✻ Fix login bug [Idle]
@@ -21,6 +22,7 @@ $ tcmux list-windows -A  # Show all windows, not just coding agents
 4: htop (1 panes)
 5: docs (1 panes) ✻ Update README [Idle]
 7: review (1 panes) ⬢ Review PR [Waiting]
+8: codex (1 panes) ❂ Refactor parser [Running]
 
 $ tcmux list-sessions  # List tmux sessions with coding agent status (alias: ls)
 dev: 7 windows (attached) - 3 Idle, 1 Running, 1 Waiting
@@ -34,6 +36,7 @@ work: 1 window
 |-------|------|-----------|
 | Claude Code | ✻ | pane title starts with `✳` or Braille spinner, process is `claude` or `node` |
 | GitHub Copilot CLI | ⬢ | process is `copilot` |
+| Codex | ❂ | process is `codex` |
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `tcmux` is a **t**erminal and **c**oding agent **mux** viewer.
 
-Supports [Claude Code](https://claude.ai/code), [GitHub Copilot CLI](https://github.com/github/copilot-cli), and Codex.
+Supports [Claude Code](https://claude.ai/code), [GitHub Copilot CLI](https://github.com/github/copilot-cli), and [Codex CLI](https://github.com/openai/codex).
 
 ## Usage
 
@@ -36,7 +36,7 @@ work: 1 window
 |-------|------|-----------|
 | Claude Code | ✻ | pane title starts with `✳` or Braille spinner, process is `claude` or `node` |
 | GitHub Copilot CLI | ⬢ | process is `copilot` |
-| Codex | ❂ | process name starts with `codex` (e.g. `codex`, `codex-aarch64-a`) |
+| Codex CLI | ❂ | process name starts with `codex` (e.g. `codex`, `codex-aarch64-a`) |
 
 ### Options
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -6,6 +6,7 @@ type Type string
 const (
 	TypeClaude  Type = "claude"
 	TypeCopilot Type = "copilot"
+	TypeCodex   Type = "codex"
 )
 
 // Status represents the status of a coding agent instance.
@@ -43,6 +44,7 @@ type Detector interface {
 var detectors = []Detector{
 	&ClaudeAgent{},
 	&CopilotAgent{},
+	&CodexAgent{},
 }
 
 // Detect checks if a pane might be running a coding agent.

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -47,6 +47,12 @@ func TestDetect(t *testing.T) {
 			wantType:       TypeCopilot,
 		},
 		{
+			name:           "Codex CLI",
+			title:          "Codex",
+			currentCommand: "codex",
+			wantType:       TypeCodex,
+		},
+		{
 			name:           "Normal shell",
 			title:          "zsh",
 			currentCommand: "zsh",

--- a/agent/codex.go
+++ b/agent/codex.go
@@ -1,0 +1,43 @@
+package agent
+
+import "strings"
+
+// CodexAgent detects and parses Codex CLI instances.
+type CodexAgent struct{}
+
+func (a *CodexAgent) Type() Type {
+	return TypeCodex
+}
+
+func (a *CodexAgent) Icon() string {
+	return "❂"
+}
+
+// MayBeTitle checks if the pane title may indicate a Codex CLI instance.
+// Title check is permissive - process name is the primary signal.
+func (a *CodexAgent) MayBeTitle(title string) bool {
+	return true
+}
+
+// MayBeProcess checks if the current command may be a Codex CLI process.
+func (a *CodexAgent) MayBeProcess(currentCommand string) bool {
+	currentCommand = strings.ToLower(strings.TrimSpace(currentCommand))
+	return currentCommand == "codex" || strings.HasPrefix(currentCommand, "codex-")
+}
+
+// ExtractSummary extracts the task summary from the pane title.
+func (a *CodexAgent) ExtractSummary(title string) string {
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return ""
+	}
+	if title == "Codex" {
+		return ""
+	}
+	return title
+}
+
+// ParseStatus parses the pane content and determines the Codex CLI status.
+func (a *CodexAgent) ParseStatus(content string) Status {
+	return parseCodexStatus(content)
+}

--- a/agent/codex.go
+++ b/agent/codex.go
@@ -27,13 +27,23 @@ func (a *CodexAgent) MayBeProcess(currentCommand string) bool {
 
 // ExtractSummary extracts the task summary from the pane title.
 func (a *CodexAgent) ExtractSummary(title string) string {
+	// Remove common emoji prefixes.
 	title = strings.TrimSpace(title)
 	if title == "" {
 		return ""
 	}
-	if title == "Codex" {
+	if len(title) > 0 {
+		r := []rune(title)
+		if len(r) > 0 && r[0] > 0x1F000 {
+			title = strings.TrimSpace(string(r[1:]))
+		}
+	}
+
+	// Treat default Codex title / host-like local title as empty summary.
+	if title == "Codex" || strings.HasSuffix(strings.ToLower(title), ".local") {
 		return ""
 	}
+
 	return title
 }
 

--- a/agent/codex_test.go
+++ b/agent/codex_test.go
@@ -60,6 +60,8 @@ func TestCodexAgent_ExtractSummary(t *testing.T) {
 		{"Default title", "Codex", ""},
 		{"Custom title", "Implement feature", "Implement feature"},
 		{"Trim spaces", "  Fix bug  ", "Fix bug"},
+		{"Title with emoji prefix", "🤖 Refactor parser", "Refactor parser"},
+		{"Local host title", "tailor.local", ""},
 		{"Empty", "", ""},
 	}
 
@@ -111,6 +113,13 @@ Press enter to confirm or esc to cancel`,
 			name: "Idle with prompt",
 			content: `Previous output
 ❯ `,
+			wantState: StateIdle,
+		},
+		{
+			name: "Idle with model progress footer",
+			content: `Previous output
+❯ Type a message
+gpt-5.3-codex high · 67% left · ~/src/github.com/k1LoW/tcmux`,
 			wantState: StateIdle,
 		},
 		{

--- a/agent/codex_test.go
+++ b/agent/codex_test.go
@@ -1,0 +1,151 @@
+package agent
+
+import "testing"
+
+func TestCodexAgent_MayBeTitle(t *testing.T) {
+	agent := &CodexAgent{}
+	tests := []struct {
+		name  string
+		title string
+		want  bool
+	}{
+		{"Codex default title", "Codex", true},
+		{"Custom title", "Implement feature", true},
+		{"Any title is accepted", "zsh", true},
+		{"Empty title", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := agent.MayBeTitle(tt.title)
+			if got != tt.want {
+				t.Errorf("CodexAgent.MayBeTitle(%q) = %v, want %v", tt.title, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCodexAgent_MayBeProcess(t *testing.T) {
+	agent := &CodexAgent{}
+	tests := []struct {
+		name           string
+		currentCommand string
+		want           bool
+	}{
+		{"Codex binary", "codex", true},
+		{"Codex wrapped binary name", "codex-aarch64-a", true},
+		{"Copilot binary", "copilot", false},
+		{"Claude binary", "claude", false},
+		{"Zsh shell", "zsh", false},
+		{"Empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := agent.MayBeProcess(tt.currentCommand)
+			if got != tt.want {
+				t.Errorf("CodexAgent.MayBeProcess(%q) = %v, want %v", tt.currentCommand, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCodexAgent_ExtractSummary(t *testing.T) {
+	agent := &CodexAgent{}
+	tests := []struct {
+		name  string
+		title string
+		want  string
+	}{
+		{"Default title", "Codex", ""},
+		{"Custom title", "Implement feature", "Implement feature"},
+		{"Trim spaces", "  Fix bug  ", "Fix bug"},
+		{"Empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := agent.ExtractSummary(tt.title)
+			if got != tt.want {
+				t.Errorf("CodexAgent.ExtractSummary(%q) = %q, want %q", tt.title, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCodexAgent_ParseStatus(t *testing.T) {
+	agent := &CodexAgent{}
+	tests := []struct {
+		name      string
+		content   string
+		wantState string
+		wantMode  string
+	}{
+		{
+			name: "Running with Esc to cancel",
+			content: `Planning update...
+● Updating files (Esc to cancel · 120 B)`,
+			wantState: StateRunning,
+		},
+		{
+			name:      "Running with elapsed and esc to interrupt",
+			content:   `• Working (29s • esc to interrupt)`,
+			wantState: StateRunning,
+		},
+		{
+			name: "Waiting with command approval",
+			content: `Do you want to allow this command?
+Confirm with number keys or ↑↓ keys and Enter, Cancel with Esc`,
+			wantState: StateWaiting,
+		},
+		{
+			name: "Waiting with codex approval prompt",
+			content: `Would you like to run the following command?
+› 1. Yes, proceed (y)
+  2. Yes, and don't ask again
+  3. No, and tell Codex what to do differently (esc)
+Press enter to confirm or esc to cancel`,
+			wantState: StateWaiting,
+		},
+		{
+			name: "Idle with prompt",
+			content: `Previous output
+❯ `,
+			wantState: StateIdle,
+		},
+		{
+			name: "Plan mode with Idle",
+			content: `Some output
+• Model changed to gpt-5.3-codex medium for Plan mode.
+❯ Type a message`,
+			wantState: StateIdle,
+			wantMode:  ModePlan,
+		},
+		{
+			name: "Default mode overrides previous plan mode",
+			content: `• Model changed to gpt-5.3-codex medium for Plan mode.
+• Model changed to gpt-5.3-codex high for Default mode.
+❯`,
+			wantState: StateIdle,
+			wantMode:  "",
+		},
+		{
+			name: "Unknown state",
+			content: `Some random output
+without any recognizable pattern`,
+			wantState: StateUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := agent.ParseStatus(tt.content)
+			if got.State != tt.wantState {
+				t.Errorf("CodexAgent.ParseStatus().State = %q, want %q", got.State, tt.wantState)
+			}
+			if got.Mode != tt.wantMode {
+				t.Errorf("CodexAgent.ParseStatus().Mode = %q, want %q", got.Mode, tt.wantMode)
+			}
+		})
+	}
+}

--- a/agent/status_codex.go
+++ b/agent/status_codex.go
@@ -1,0 +1,105 @@
+package agent
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Codex CLI status indicators.
+var (
+	// Running patterns.
+	codexRunningParenPattern = regexp.MustCompile(`(?i)\([^)]*(Esc to cancel|esc to interrupt|ctrl\+c to interrupt)`)
+
+	// Waiting patterns.
+	codexWaitingPatterns = []string{
+		"Do you want to run this command?",
+		"Do you want to allow this command?",
+		"Confirm with number keys",
+		"Cancel with Esc",
+		"approval required",
+		"Would you like to run the following command?",
+		"Yes, proceed (y)",
+		"No, and tell Codex what to do differently",
+		"Press enter to confirm or esc to cancel",
+	}
+
+	// Mode patterns.
+	codexPlanModePattern    = regexp.MustCompile(`(?i)(plan mode\s*·|collaboration mode:\s*plan|for plan mode|you are now in plan mode|#\s*plan mode\b)`)
+	codexDefaultModePattern = regexp.MustCompile(`(?i)(for default mode|you are now in default mode|collaboration mode:\s*default)`)
+	codexAcceptModePattern  = regexp.MustCompile(`(?i)accept edits`)
+)
+
+// parseCodexStatus parses the pane content and determines the Codex CLI status.
+func parseCodexStatus(content string) Status {
+	lines := strings.Split(content, "\n")
+	lastLines := lastNonEmptyLines(lines, 30)
+	combined := strings.Join(lastLines, "\n")
+
+	status := Status{
+		State:       StateUnknown,
+		Mode:        "",
+		Description: "",
+	}
+
+	status.Mode = detectCodexMode(lastLines)
+
+	if codexRunningParenPattern.MatchString(combined) {
+		status.State = StateRunning
+		return status
+	}
+
+	if isCodexPromptLine(lines) {
+		status.State = StateIdle
+		return status
+	}
+
+	for _, pattern := range codexWaitingPatterns {
+		if strings.Contains(combined, pattern) {
+			status.State = StateWaiting
+			return status
+		}
+	}
+
+	return status
+}
+
+func detectCodexMode(lines []string) string {
+	mode := ""
+	for _, line := range lines {
+		switch {
+		case codexDefaultModePattern.MatchString(line):
+			mode = ""
+		case codexPlanModePattern.MatchString(line):
+			mode = ModePlan
+		case codexAcceptModePattern.MatchString(line):
+			mode = ModeAcceptEdits
+		}
+	}
+	return mode
+}
+
+// isCodexPromptLine checks if the last non-empty, non-separator line is a prompt.
+func isCodexPromptLine(lines []string) bool {
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		if isSeparatorLine(line) {
+			continue
+		}
+		if strings.Contains(line, "? for shortcuts") ||
+			strings.Contains(line, "ctrl+") ||
+			strings.Contains(line, "shift+") ||
+			strings.Contains(line, "Remaining requests:") {
+			continue
+		}
+		if strings.HasPrefix(line, "❯") ||
+			strings.HasPrefix(line, "›") ||
+			line == ">" {
+			return true
+		}
+		return false
+	}
+	return false
+}

--- a/agent/status_codex.go
+++ b/agent/status_codex.go
@@ -24,9 +24,10 @@ var (
 	}
 
 	// Mode patterns.
-	codexPlanModePattern    = regexp.MustCompile(`(?i)(plan mode\s*·|collaboration mode:\s*plan|for plan mode|you are now in plan mode|#\s*plan mode\b)`)
-	codexDefaultModePattern = regexp.MustCompile(`(?i)(for default mode|you are now in default mode|collaboration mode:\s*default)`)
-	codexAcceptModePattern  = regexp.MustCompile(`(?i)accept edits`)
+	codexPlanModePattern       = regexp.MustCompile(`(?i)(plan mode\s*·|collaboration mode:\s*plan|for plan mode|you are now in plan mode|#\s*plan mode\b)`)
+	codexDefaultModePattern    = regexp.MustCompile(`(?i)(for default mode|you are now in default mode|collaboration mode:\s*default)`)
+	codexAcceptModePattern     = regexp.MustCompile(`(?i)accept edits`)
+	codexProgressFooterPattern = regexp.MustCompile(`\b\d{1,3}% left\b`)
 )
 
 // parseCodexStatus parses the pane content and determines the Codex CLI status.
@@ -91,7 +92,8 @@ func isCodexPromptLine(lines []string) bool {
 		if strings.Contains(line, "? for shortcuts") ||
 			strings.Contains(line, "ctrl+") ||
 			strings.Contains(line, "shift+") ||
-			strings.Contains(line, "Remaining requests:") {
+			strings.Contains(line, "Remaining requests:") ||
+			(strings.Contains(line, "·") && codexProgressFooterPattern.MatchString(line)) {
 			continue
 		}
 		if strings.HasPrefix(line, "❯") ||

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -19,7 +19,7 @@ var lsCmd = &cobra.Command{
 	Use:     "list-sessions",
 	Aliases: []string{"ls"},
 	Short:   "List tmux sessions with coding agent status",
-	Long:    `List tmux sessions with coding agent status (Claude Code, Copilot CLI, Codex).`,
+	Long:    `List tmux sessions with coding agent status (Claude Code, Copilot CLI, and Codex CLI).`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Use format string if specified, otherwise use default
 		format := lsFormat

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -19,7 +19,7 @@ var lsCmd = &cobra.Command{
 	Use:     "list-sessions",
 	Aliases: []string{"ls"},
 	Short:   "List tmux sessions with coding agent status",
-	Long:    `List tmux sessions with coding agent status (Claude Code, Copilot CLI).`,
+	Long:    `List tmux sessions with coding agent status (Claude Code, Copilot CLI, Codex).`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Use format string if specified, otherwise use default
 		format := lsFormat

--- a/cmd/lsw.go
+++ b/cmd/lsw.go
@@ -23,7 +23,7 @@ var lswCmd = &cobra.Command{
 	Use:     "list-windows",
 	Aliases: []string{"lsw"},
 	Short:   "List coding agent instances running in tmux windows",
-	Long:    `List coding agent instances (Claude Code, Copilot CLI) running in tmux windows with their status.`,
+	Long:    `List coding agent instances (Claude Code, Copilot CLI, Codex) running in tmux windows with their status.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Use format string if specified, otherwise use default
 		format := lswFormat

--- a/cmd/lsw.go
+++ b/cmd/lsw.go
@@ -23,7 +23,7 @@ var lswCmd = &cobra.Command{
 	Use:     "list-windows",
 	Aliases: []string{"lsw"},
 	Short:   "List coding agent instances running in tmux windows",
-	Long:    `List coding agent instances (Claude Code, Copilot CLI, Codex) running in tmux windows with their status.`,
+	Long:    `List coding agent instances (Claude Code, Copilot CLI, and Codex CLI) running in tmux windows with their status.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Use format string if specified, otherwise use default
 		format := lswFormat

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ var colorMode string
 var rootCmd = &cobra.Command{
 	Use:   "tcmux",
 	Short: "terminal and coding agent mux viewer",
-	Long:  `tcmux is a terminal and coding agent mux viewer (supports Claude Code, Copilot CLI).`,
+	Long:  `tcmux is a terminal and coding agent mux viewer (supports Claude Code, Copilot CLI, Codex).`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return output.SetColorMode(colorMode)
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ var colorMode string
 var rootCmd = &cobra.Command{
 	Use:   "tcmux",
 	Short: "terminal and coding agent mux viewer",
-	Long:  `tcmux is a terminal and coding agent mux viewer (supports Claude Code, Copilot CLI, Codex).`,
+	Long:  `tcmux is a terminal and coding agent mux viewer (supports Claude Code, Copilot CLI, and Codex CLI).`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return output.SetColorMode(colorMode)
 	},

--- a/output/color.go
+++ b/output/color.go
@@ -42,7 +42,7 @@ func initOutput(o *termenv.Output) {
 	modeColor = output.Color("#B366FF")         // Purple/Magenta
 	claudeThemeColor = output.Color("#E5A000")  // Claude Code orange
 	copilotThemeColor = output.Color("#8534F3") // Copilot purple (official brand color)
-	codexThemeColor = output.Color("#5B6CFF")   // Codex blue-violet
+	codexThemeColor = output.Color("#9EB3F1")   // Codex logo color
 }
 
 // SetColorMode sets the color output mode: always, never, or auto.

--- a/output/color.go
+++ b/output/color.go
@@ -24,6 +24,9 @@ var (
 
 	// Copilot CLI theme color
 	copilotThemeColor termenv.Color
+
+	// Codex theme color
+	codexThemeColor termenv.Color
 )
 
 func init() {
@@ -39,6 +42,7 @@ func initOutput(o *termenv.Output) {
 	modeColor = output.Color("#B366FF")         // Purple/Magenta
 	claudeThemeColor = output.Color("#E5A000")  // Claude Code orange
 	copilotThemeColor = output.Color("#8534F3") // Copilot purple (official brand color)
+	codexThemeColor = output.Color("#5B6CFF")   // Codex blue-violet
 }
 
 // SetColorMode sets the color output mode: always, never, or auto.

--- a/output/format.go
+++ b/output/format.go
@@ -155,6 +155,8 @@ func formatAgentStatus(instances []AgentInfo) string {
 			themeColor = claudeThemeColor
 		case agent.TypeCopilot:
 			themeColor = copilotThemeColor
+		case agent.TypeCodex:
+			themeColor = codexThemeColor
 		default:
 			themeColor = claudeThemeColor
 		}

--- a/output/format_test.go
+++ b/output/format_test.go
@@ -167,6 +167,17 @@ func TestExpandFormat(t *testing.T) {
 			want: "⬢ [Running]",
 		},
 		{
+			name:   "Codex CLI instance",
+			format: "#{agent_status}",
+			ctx: &FormatContext{
+				TmuxVars: map[string]string{},
+				AgentInstances: []AgentInfo{
+					{AgentType: agent.TypeCodex, Icon: "❂", Summary: "Refactor parser", Status: agent.Status{State: agent.StateIdle}},
+				},
+			},
+			want: "❂ Refactor parser [Idle]",
+		},
+		{
 			name:   "Mixed agents",
 			format: "#{agent_status}",
 			ctx: &FormatContext{
@@ -174,9 +185,10 @@ func TestExpandFormat(t *testing.T) {
 				AgentInstances: []AgentInfo{
 					{AgentType: agent.TypeClaude, Icon: "✻", Summary: "Fix login bug", Status: agent.Status{State: agent.StateIdle}},
 					{AgentType: agent.TypeCopilot, Icon: "⬢", Summary: "", Status: agent.Status{State: agent.StateRunning}},
+					{AgentType: agent.TypeCodex, Icon: "❂", Summary: "", Status: agent.Status{State: agent.StateWaiting}},
 				},
 			},
-			want: "✻ Fix login bug [Idle], ⬢ [Running]",
+			want: "✻ Fix login bug [Idle], ⬢ [Running], ❂ [Waiting]",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- add Codex CLI detector and status parser
- support Codex mode/state detection in agent_status output
- add Codex icon/theme and update docs/help text
- improve Codex summary handling for default .local titles

ref: https://github.com/k1LoW/tcmux/issues/5